### PR TITLE
Add metadata endpoint with generic service

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,16 @@ env $(cat .env | xargs) mvn spring-boot:run
 | `/mcp/metadata/short`    | Metadata reducida (resumen)         |
 | `/mcp/chunks`            | Chunks de contenido (con filtros)   |
 
-5. Ejemplo:
+5. Ejemplos:
 
-```
+```bash
+# Metadata completa desde SQL
+curl 'http://localhost:8090/mcp/metadata?source=sql'
+
+# Metadata via REST (TMDB)
+curl 'http://localhost:8090/mcp/metadata?source=rest'
+
+# Chunks filtrados por título
 curl 'http://localhost:8090/mcp/chunks?table=film&filter=title=%27Thor%27&source=sql'
 ```
 

--- a/src/main/java/org/shark/melian/controller/MetadataController.java
+++ b/src/main/java/org/shark/melian/controller/MetadataController.java
@@ -3,6 +3,8 @@ package org.shark.melian.controller;
 
 import org.shark.melian.model.TableShortDto;
 import org.shark.melian.service.MetadataService;
+import org.shark.melian.model.DatabaseMetadataDto;
+import org.shark.melian.model.McpMetadataDto;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,12 +17,12 @@ import java.util.List;
 @RequestMapping("/mcp/metadata")
 public class MetadataController {
 
-    private final MetadataService sqlMetadataService;
-    private final MetadataService restApiMetadataService;
+    private final MetadataService<DatabaseMetadataDto> sqlMetadataService;
+    private final MetadataService<McpMetadataDto> restApiMetadataService;
 
     public MetadataController(
-            @Qualifier("sqlMetadataService") MetadataService sqlMetadataService,
-            @Qualifier("restApiMetadataService") MetadataService restApiMetadataService
+            @Qualifier("sqlMetadataService") MetadataService<DatabaseMetadataDto> sqlMetadataService,
+            @Qualifier("restApiMetadataService") MetadataService<McpMetadataDto> restApiMetadataService
     ) {
         this.sqlMetadataService = sqlMetadataService;
         this.restApiMetadataService = restApiMetadataService;
@@ -32,5 +34,18 @@ public class MetadataController {
             return restApiMetadataService.extractShortSummary();
         }
         return sqlMetadataService.extractShortSummary();
+    }
+
+    /**
+     * Returns the complete metadata description for the selected source.
+     * If {@code source=rest} a {@link McpMetadataDto} is returned, otherwise a
+     * {@link DatabaseMetadataDto}.
+     */
+    @GetMapping
+    public Object getMetadata(@RequestParam(name = "source", defaultValue = "sql") String source) {
+        if ("rest".equalsIgnoreCase(source)) {
+            return restApiMetadataService.extractMetadata();
+        }
+        return sqlMetadataService.extractMetadata();
     }
 }

--- a/src/main/java/org/shark/melian/service/MetadataService.java
+++ b/src/main/java/org/shark/melian/service/MetadataService.java
@@ -1,13 +1,22 @@
 package org.shark.melian.service;
 
 
-import org.shark.melian.model.DatabaseMetadataDto;
 import org.shark.melian.model.TableShortDto;
+
+/**
+ * Generic contract for extracting metadata information. Implementations may
+ * return either a {@link org.shark.melian.model.DatabaseMetadataDto} or a
+ * {@link org.shark.melian.model.McpMetadataDto} depending on the backend.
+ */
 
 import java.util.List;
 
-public interface MetadataService {
-    DatabaseMetadataDto extractMetadata();
+public interface MetadataService<T> {
+    /**
+     * Extracts full metadata representation. Implementations decide the
+     * concrete DTO returned.
+     */
+    T extractMetadata();
 
     List<TableShortDto> extractShortSummary();
 }

--- a/src/main/java/org/shark/melian/service/RestApiMetadataService.java
+++ b/src/main/java/org/shark/melian/service/RestApiMetadataService.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service("restApiMetadataService")
-public class RestApiMetadataService implements MetadataService {
+public class RestApiMetadataService implements MetadataService<McpMetadataDto> {
 
     // Tablas virtuales con metadata descriptiva
     private List<TableMetadataDto> tmdbVirtualTables() {
@@ -28,9 +28,15 @@ public class RestApiMetadataService implements MetadataService {
 
 
     @Override
-    public DatabaseMetadataDto extractMetadata() {
-        DatabaseMetadataDto result = new DatabaseMetadataDto();
-        result.setTables(tmdbVirtualTables());
+    public McpMetadataDto extractMetadata() {
+        McpMetadataDto result = new McpMetadataDto();
+        result.setName("TMDB");
+        result.setDescription("Virtual metadata extracted from TMDB API");
+        result.setVersion("1.0");
+        result.setBuildDate(null);
+        result.setCapabilities(List.of("chunks"));
+        result.setTypes(List.of("film"));
+        result.setDatabase(new DatabaseMetadataDto(tmdbVirtualTables()));
         return result;
     }
 

--- a/src/main/java/org/shark/melian/service/SqlMetadataService.java
+++ b/src/main/java/org/shark/melian/service/SqlMetadataService.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 @Service("sqlMetadataService")
-public class SqlMetadataService implements MetadataService {
+public class SqlMetadataService implements MetadataService<DatabaseMetadataDto> {
 
     private final DataSource dataSource;
 


### PR DESCRIPTION
## Summary
- implement generic `MetadataService` to allow different return DTOs
- add `getMetadata` endpoint in `MetadataController`
- return `McpMetadataDto` from REST metadata service
- document metadata examples in README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685347258334832ea54b57a7be7a243c