### PR TITLE
Add movie search services

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ curl 'http://localhost:8090/mcp/metadata?source=rest'
 curl 'http://localhost:8090/mcp/chunks?table=film&filter=title=%27Thor%27&source=sql'
 ```
 
+
+### Herramientas de búsqueda de películas
+
+MELIAN expone tres herramientas simples para consultar películas desde distintos orígenes:
+
+- `search_movies_tmdb` consulta la API pública de TMDB.
+- `search_movies_sql` lee la tabla `film` de la base de datos SQL.
+- `search_movies_mongo` consulta la colección `film` en MongoDB.
+
 ---
 
 ## Roadmap

--- a/src/main/java/org/shark/melian/service/MovieMongoService.java
+++ b/src/main/java/org/shark/melian/service/MovieMongoService.java
@@ -1,0 +1,34 @@
+package org.shark.melian.service;
+
+import org.bson.Document;
+import org.shark.melian.model.MovieResult;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MovieMongoService {
+    private final MongoTemplate mongoTemplate;
+
+    public MovieMongoService(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    public List<MovieResult> search(String title, int limit) {
+        Query query = Query.query(Criteria.where("title").regex(title, "i")).limit(limit);
+        return mongoTemplate.find(query, Document.class, "film")
+                .stream()
+                .map(doc -> new MovieResult(
+                        doc.getString("title"),
+                        doc.getString("description"),
+                        String.valueOf(doc.get("release_year")),
+                        doc.get("imdb_rating") instanceof Number
+                                ? ((Number) doc.get("imdb_rating")).doubleValue()
+                                : 0.0
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/org/shark/melian/service/MovieSqlService.java
+++ b/src/main/java/org/shark/melian/service/MovieSqlService.java
@@ -1,0 +1,35 @@
+package org.shark.melian.service;
+
+import org.shark.melian.model.MovieResult;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MovieSqlService {
+    private final JdbcTemplate jdbcTemplate;
+
+    public MovieSqlService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<MovieResult> search(String title, int limit) {
+        String sql = """
+                SELECT title, description, release_year, imdb_rating
+                FROM film
+                WHERE LOWER(title) LIKE LOWER(?)
+                LIMIT ?
+                """;
+        return jdbcTemplate.query(
+                sql,
+                (rs, i) -> new MovieResult(
+                        rs.getString("title"),
+                        rs.getString("description"),
+                        rs.getString("release_year"),
+                        rs.getDouble("imdb_rating")
+                ),
+                "%" + title + "%", limit
+        );
+    }
+}

--- a/src/main/java/org/shark/melian/service/MovieToolService.java
+++ b/src/main/java/org/shark/melian/service/MovieToolService.java
@@ -8,14 +8,30 @@ import java.util.List;
 
 @Service
 public class MovieToolService {
-	private final TMDBService tmdb;
+    private final TMDBService tmdb;
+    private final MovieSqlService movieSqlService;
+    private final MovieMongoService movieMongoService;
 
-    public MovieToolService(TMDBService tmdbService) {
+    public MovieToolService(TMDBService tmdbService,
+                            MovieSqlService movieSqlService,
+                            MovieMongoService movieMongoService) {
         this.tmdb = tmdbService;
+        this.movieSqlService = movieSqlService;
+        this.movieMongoService = movieMongoService;
     }
 
-    @Tool(name = "search_movies_by_tmdb_api", description = "Busca peliculas por titulo usando la API de TMDB")
-	public List<MovieResult> searchMovies(String title, Integer limit) {
-		return tmdb.search(title, limit != null ? limit : 3);
-	}
+    @Tool(name = "search_movies_tmdb", description = "Busca peliculas por titulo usando la API de TMDB")
+    public List<MovieResult> searchMoviesApi(String title, Integer limit) {
+        return tmdb.search(title, limit != null ? limit : 3);
+    }
+
+    @Tool(name = "search_movies_sql", description = "Busca peliculas por titulo usando la base SQL")
+    public List<MovieResult> searchMoviesSql(String title, Integer limit) {
+        return movieSqlService.search(title, limit != null ? limit : 3);
+    }
+
+    @Tool(name = "search_movies_mongo", description = "Busca peliculas por titulo usando MongoDB")
+    public List<MovieResult> searchMoviesMongo(String title, Integer limit) {
+        return movieMongoService.search(title, limit != null ? limit : 3);
+    }
 }


### PR DESCRIPTION
## Summary
- support movie search using SQL or MongoDB
- expose new tool methods `search_movies_sql` and `search_movies_mongo`
- document movie tools in README

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686edd8f2d00832e9f1d25ac28493bd2