### PR TITLE
Add basic RestAssured integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,12 @@
             <version>5.8.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/shark/melian/MelianMcpServer.java
+++ b/src/main/java/org/shark/melian/MelianMcpServer.java
@@ -36,6 +36,7 @@ public class MelianMcpServer {
     private final MovieChunkService mongoMovieService;
     private final MelianMcpTools mcpTools;
     private final MelianMcpResources mcpResources;
+    private HttpServer httpServer;
 
     public MelianMcpServer() {
         log.info("Initializing MELIAN MCP Server...");
@@ -148,7 +149,8 @@ public class MelianMcpServer {
 
         McpHttpController httpController = new McpHttpController(mcpTools, mcpResources);
 
-        HttpServer server = HttpServer.create(new InetSocketAddress(host, port), 0);
+        httpServer = HttpServer.create(new InetSocketAddress(host, port), 0);
+        HttpServer server = httpServer;
 
         server.createContext("/mcp", new HttpHandler() {
             @Override
@@ -202,10 +204,17 @@ public class MelianMcpServer {
             if (mongoConfig != null) {
                 mongoConfig.close();
             }
+            if (httpServer != null) {
+                httpServer.stop(0);
+            }
         } catch (Exception e) {
             log.warn("Error during shutdown", e);
         }
 
         log.info("MELIAN MCP Server shutdown complete");
+    }
+
+    public HttpServer getHttpServer() {
+        return httpServer;
     }
 }

--- a/src/main/java/org/shark/melian/controller/McpHttpServer.java
+++ b/src/main/java/org/shark/melian/controller/McpHttpServer.java
@@ -9,7 +9,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 
 public class McpHttpServer {
-    public static void start(McpHttpController controller, int port) throws IOException {
+    public static HttpServer start(McpHttpController controller, int port) throws IOException {
         HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
         server.createContext("/mcp", new HttpHandler() {
             @Override
@@ -46,5 +46,6 @@ public class McpHttpServer {
         server.setExecutor(null);
         server.start();
         System.out.println("HTTP MCP server listening on port " + port);
+        return server;
     }
 }

--- a/src/test/java/org/shark/melian/McpServerRestAssuredIntegrationTest.java
+++ b/src/test/java/org/shark/melian/McpServerRestAssuredIntegrationTest.java
@@ -1,0 +1,87 @@
+import com.sun.net.httpserver.HttpServer;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.shark.melian.MelianMcpServer;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("integration")
+public class McpServerRestAssuredIntegrationTest {
+
+    private static MelianMcpServer server;
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        server = new MelianMcpServer();
+        var startMethod = MelianMcpServer.class.getDeclaredMethod("startHttpServer");
+        startMethod.setAccessible(true);
+        startMethod.invoke(server);
+        RestAssured.baseURI = "http://localhost";
+        RestAssured.port = 3000;
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.shutdown();
+            HttpServer httpServer = server.getHttpServer();
+            if (httpServer != null) {
+                httpServer.stop(0);
+            }
+        }
+    }
+
+    @Test
+    void healthEndpointReturnsOk() {
+        given()
+            .get("/mcp/health")
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("OK"))
+            .body("tools", notNullValue());
+    }
+
+    @Test
+    void initializeReturnsCapabilities() {
+        String request = "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1}";
+        given()
+            .body(request)
+            .header("Content-Type", "application/json")
+        .when()
+            .post("/mcp")
+        .then()
+            .statusCode(200)
+            .body("result.serverInfo.name", equalTo("melian-movie-server"))
+            .body("result.capabilities.tools", notNullValue());
+    }
+
+    @Test
+    void toolsListReturnsRegisteredTools() {
+        String request = "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":2}";
+        given()
+            .body(request)
+            .header("Content-Type", "application/json")
+        .when()
+            .post("/mcp")
+        .then()
+            .statusCode(200)
+            .body("result.tools", hasItems("search_movies", "get_movie_chunks", "get_server_status"));
+    }
+
+    @Test
+    void callGetServerStatusTool() {
+        String request = "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"get_server_status\",\"arguments\":{}},\"id\":3}";
+        given()
+            .body(request)
+            .header("Content-Type", "application/json")
+        .when()
+            .post("/mcp")
+        .then()
+            .statusCode(200)
+            .body("result.status", equalTo("OK"));
+    }
+}


### PR DESCRIPTION
## Summary
- allow `McpHttpServer.start` to return the started server
- expose running `HttpServer` inside `MelianMcpServer` so it can be stopped
- stop the HTTP server on shutdown
- add RestAssured dependency
- create `McpServerRestAssuredIntegrationTest` covering health check and basic MCP RPC calls

## Testing
- `./test-integration.sh` *(fails: Non-resolvable import POM: org.testcontainers:testcontainers-bom)*

------
https://chatgpt.com/codex/tasks/task_e_6880d149c6a8832eb8ba21dce655bf82