### PR TITLE
Add HTTP SSE transport option

### DIFF
--- a/EJECUTAR_SERVIDOR_MCP.md
+++ b/EJECUTAR_SERVIDOR_MCP.md
@@ -139,6 +139,23 @@ export TMDB_ACCESS_TOKEN="tu_token_tmdb_aqui"
 java -jar target/melian-0.1.0-SNAPSHOT.jar
 ```
 
+## 🌐 Modo HTTP SSE (servidor remoto)
+
+Para exponer el servidor por HTTP usando Server-Sent Events (SSE), establece la variable:
+
+```bash
+export MCP_SERVER_HTTP_ENABLED=true
+```
+
+Opcionalmente puedes configurar el puerto y host:
+
+```bash
+export MCP_SERVER_PORT=3000
+export MCP_SERVER_HOST=0.0.0.0
+```
+
+Luego ejecuta el servidor normalmente y atenderá conexiones remotas en `http://$MCP_SERVER_HOST:$MCP_SERVER_PORT/mcp/message`.
+
 ## 🔧 Obtener Token TMDB
 
 1. Ir a [https://www.themoviedb.org/](https://www.themoviedb.org/)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,14 @@ export TMDB_ACCESS_TOKEN="tu_token_tmdb_aqui"
 java -jar target/melian-0.1.0-SNAPSHOT.jar
 ```
 
+#### 6. Modo HTTP SSE (servidor remoto)
+```bash
+export MCP_SERVER_HTTP_ENABLED=true
+# Puerto opcional
+export MCP_SERVER_PORT=3000
+java -jar target/melian-0.1.0-SNAPSHOT.jar
+```
+
 ### ✅ Verificación del servidor
 
 Cuando el servidor esté corriendo verás:

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,18 @@
             <artifactId>HikariCP</artifactId>
             <version>5.1.0</version>
         </dependency>
+
+        <!-- Jetty for HTTP SSE server -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>11.0.17</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>11.0.17</version>
+        </dependency>
         
         <!-- Lombok -->
         <dependency>

--- a/run-mcp-server.sh
+++ b/run-mcp-server.sh
@@ -67,8 +67,9 @@ echo "1. Básica (H2 en memoria)"
 echo "2. Con MongoDB (requiere Docker)"
 echo "3. Con MySQL (requiere Docker)"
 echo "4. Completa (MySQL + MongoDB + Docker)"
+echo "5. HTTP SSE (exponer servidor remoto)"
 echo ""
-echo "Selecciona una opción (1-4) o presiona Enter para básica:"
+echo "Selecciona una opción (1-5) o presiona Enter para básica:"
 read -r option
 
 case "$option" in
@@ -108,6 +109,10 @@ case "$option" in
         export DB_DRIVER="com.mysql.cj.jdbc.Driver"
         export MONGODB_URI="mongodb://root:example@localhost:27017"
         echo "✅ MySQL y MongoDB configurados"
+        ;;
+    5)
+        echo "🌐 Iniciando en modo HTTP SSE"
+        export MCP_SERVER_HTTP_ENABLED=true
         ;;
     *)
         echo "✅ Usando configuración básica (H2 en memoria)"

--- a/src/main/java/org/shark/melian/MelianMcpServer.java
+++ b/src/main/java/org/shark/melian/MelianMcpServer.java
@@ -3,6 +3,7 @@ package org.shark.melian;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.McpSyncServerBuilder;
 import io.modelcontextprotocol.server.transport.McpSyncServerTransport;
+import io.modelcontextprotocol.server.transport.http.servlet.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.server.transport.stdio.StdioTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.shark.melian.client.TMDBApiClientPure;
@@ -18,7 +19,13 @@ import org.shark.melian.service.TMDBServicePure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
 import java.io.IOException;
+import java.net.InetSocketAddress;
 
 public class MelianMcpServer {
 
@@ -27,6 +34,7 @@ public class MelianMcpServer {
     private final MelianConfig config;
     private final DatabaseConfig databaseConfig;
     private final MongoConfig mongoConfig;
+    private Server httpServer;
     private final TMDBApiClientPure tmdbClient;
     private final TMDBServicePure tmdbService;
     private final MovieChunkService sqlMovieService;
@@ -146,8 +154,12 @@ public class MelianMcpServer {
         MelianMcpServer server = new MelianMcpServer();
         Runtime.getRuntime().addShutdownHook(new Thread(server::shutdown));
         try {
-            server.startStdioServer();
-        } catch (IOException e) {
+            if (server.getConfig().getBooleanProperty("mcp.server.http.enabled", false)) {
+                server.startHttpServer();
+            } else {
+                server.startStdioServer();
+            }
+        } catch (Exception e) {
             log.error("Error starting MCP server", e);
         }
     }
@@ -156,6 +168,26 @@ public class MelianMcpServer {
         McpSyncServerTransport transport = new StdioTransport();
         mcpServer.start(transport);
         log.info("MCP server started on STDIO transport");
+    }
+
+    private void startHttpServer() throws Exception {
+        int port = config.getIntProperty("mcp.server.port", 3000);
+        String host = config.getProperty("mcp.server.host", "0.0.0.0");
+
+        ObjectMapper mapper = new ObjectMapper();
+        HttpServletSseServerTransportProvider transport =
+                new HttpServletSseServerTransportProvider(mapper, "/mcp/message");
+
+        httpServer = new Server(new InetSocketAddress(host, port));
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(transport), "/mcp/message");
+        httpServer.setHandler(context);
+
+        mcpServer.start(transport);
+        httpServer.start();
+        log.info("MCP server started on HTTP SSE transport at {}:{}", host, port);
+        httpServer.join();
     }
 
     public void shutdown() {
@@ -174,6 +206,9 @@ public class MelianMcpServer {
             if (mcpServer != null) {
                 mcpServer.stop();
             }
+            if (httpServer != null) {
+                httpServer.stop();
+            }
         } catch (Exception e) {
             log.warn("Error during shutdown", e);
         }
@@ -183,5 +218,9 @@ public class MelianMcpServer {
 
     public McpSyncServer getMcpServer() {
         return mcpServer;
+    }
+
+    public MelianConfig getConfig() {
+        return config;
     }
 }

--- a/src/main/java/org/shark/melian/config/MelianConfig.java
+++ b/src/main/java/org/shark/melian/config/MelianConfig.java
@@ -41,6 +41,7 @@ public class MelianConfig {
         // MCP Server configuration - usar 0.0.0.0 para Docker
         setPropertyFromEnv("mcp.server.port", "MCP_SERVER_PORT", "3000");
         setPropertyFromEnv("mcp.server.host", "MCP_SERVER_HOST", "0.0.0.0");
+        setPropertyFromEnv("mcp.server.http.enabled", "MCP_SERVER_HTTP_ENABLED", "false");
     }
 
     private void setPropertyFromEnv(String propKey, String envKey, String defaultValue) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,4 @@ tmdb.access-token=
 # MCP Server Configuration
 mcp.server.port=3000
 mcp.server.host=localhost
+mcp.server.http.enabled=false


### PR DESCRIPTION
## Summary
- enable HTTP SSE transport using Jetty
- document remote execution in README and run instructions
- add Jetty dependencies for the new server
- support HTTP mode in run script and config

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_688be684bb4c832e9c1e19089b895278