### PR TITLE
Add REST endpoints for movie search and chunk retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ El servidor proporciona:
   - `server/docs`: Documentación del servidor y guía de uso
 - 🗄️ **Múltiples fuentes**: SQL (H2/MySQL), MongoDB, TMDB API
 - 🚀 **Protocolo estándar**: Compatible con cualquier cliente MCP
+- 🌐 **Servicios REST**: `/api/search` y `/api/chunks` para integración ligera
 
 ---
 

--- a/src/main/java/org/shark/melian/MelianMcpServer.java
+++ b/src/main/java/org/shark/melian/MelianMcpServer.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.shark.melian.rest.SearchMoviesServlet;
+import org.shark.melian.rest.MovieChunksServlet;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -182,6 +184,8 @@ public class MelianMcpServer {
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
         context.setContextPath("/");
         context.addServlet(new ServletHolder(transport), "/mcp/message");
+        context.addServlet(new ServletHolder(new SearchMoviesServlet(tmdbService)), "/api/search");
+        context.addServlet(new ServletHolder(new MovieChunksServlet(sqlMovieService, mongoMovieService)), "/api/chunks");
         httpServer.setHandler(context);
 
         mcpServer.start(transport);

--- a/src/main/java/org/shark/melian/rest/MovieChunksServlet.java
+++ b/src/main/java/org/shark/melian/rest/MovieChunksServlet.java
@@ -1,0 +1,46 @@
+package org.shark.melian.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.shark.melian.service.MovieChunkService;
+import org.shark.melian.model.ChunkDto;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Servlet that exposes movie chunks from SQL or Mongo storage as JSON.
+ */
+public class MovieChunksServlet extends HttpServlet {
+
+    private final MovieChunkService sqlService;
+    private final MovieChunkService mongoService;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public MovieChunksServlet(MovieChunkService sqlService, MovieChunkService mongoService) {
+        this.sqlService = sqlService;
+        this.mongoService = mongoService;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String source = req.getParameter("source");
+        if (source == null || source.isBlank()) {
+            source = "sql";
+        }
+        int limit = 10;
+        try {
+            if (req.getParameter("limit") != null) {
+                limit = Integer.parseInt(req.getParameter("limit"));
+            }
+        } catch (NumberFormatException ignored) { }
+        String filter = req.getParameter("filter");
+        MovieChunkService service = "mongo".equalsIgnoreCase(source) ? mongoService : sqlService;
+        List<ChunkDto> chunks = service.getMovieChunks(source, limit, null, filter, null, null);
+
+        resp.setContentType("application/json");
+        mapper.writeValue(resp.getWriter(), chunks);
+    }
+}

--- a/src/main/java/org/shark/melian/rest/SearchMoviesServlet.java
+++ b/src/main/java/org/shark/melian/rest/SearchMoviesServlet.java
@@ -1,0 +1,44 @@
+package org.shark.melian.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.shark.melian.service.TMDBServicePure;
+import org.shark.melian.model.MovieResult;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Simple servlet to search movies via TMDB API and return JSON results.
+ */
+public class SearchMoviesServlet extends HttpServlet {
+
+    private final TMDBServicePure tmdbService;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public SearchMoviesServlet(TMDBServicePure tmdbService) {
+        this.tmdbService = tmdbService;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String query = req.getParameter("query");
+        if (query == null || query.isBlank()) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.getWriter().write("Missing query parameter");
+            return;
+        }
+        int limit = 10;
+        try {
+            if (req.getParameter("limit") != null) {
+                limit = Integer.parseInt(req.getParameter("limit"));
+            }
+        } catch (NumberFormatException ignored) { }
+
+        List<MovieResult> results = tmdbService.search(query, limit);
+        resp.setContentType("application/json");
+        mapper.writeValue(resp.getWriter(), results);
+    }
+}


### PR DESCRIPTION
## Summary
- expose new REST servlets for searching movies and obtaining chunks
- wire servlets into `MelianMcpServer`
- document REST endpoints in README

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688c1a3623f8832e80c4d5a4ca1232c1