### PR TITLE
Enable spring-boot:run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,12 @@ Cada implementación de MELIAN puede ser adaptada al área, negocio o dominio:
 MELIAN ahora incluye un servidor MCP puro que cumple completamente con el estándar MCP sin dependencias de OpenAI.
 
 ```bash
+
 # Compilar el proyecto
 mvn clean package -DskipTests
+
+# También puedes iniciarlo directamente con Maven
+mvn spring-boot:run
 
 # Ejecutar servidor MCP con transporte HTTP
 MCP_SERVER_HTTP_ENABLED=true java -jar target/melian-*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <h2.version>2.2.224</h2.version>
         <logback.version>1.4.14</logback.version>
         <testcontainers.version>1.19.7</testcontainers.version>
+        <spring-boot.version>3.2.5</spring-boot.version>
     </properties>
 
     <dependencyManagement>
@@ -37,6 +38,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Spring Boot runtime -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring-boot.version}</version>
+        </dependency>
         <!-- LangChain4j MCP API -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
@@ -287,6 +294,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+                <configuration>
+                    <mainClass>org.shark.melian.mcp.MelianMcpServer</mainClass>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- add Spring Boot runtime to Maven build
- configure spring-boot-maven-plugin to run `MelianMcpServer`
- document running the server with `mvn spring-boot:run`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d67dae1fc832ea56817ee5d21abb6