### PR TITLE
feat: add swagger with spring controllers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,18 +24,6 @@
         <testcontainers.version>1.19.7</testcontainers.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- LangChain4j MCP API -->
         <dependency>
@@ -120,6 +108,18 @@
             <version>5.1.0</version>
         </dependency>
 
+        <!-- Spring Web and Swagger -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+
         <!-- Jetty for HTTP server (optional - keep for REST API) -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -157,6 +157,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -168,11 +169,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -202,7 +205,7 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>3.2.6</version>
                 <configuration>
-                    <mainClass>org.shark.melian.mcp.MelianMcpServer</mainClass>
+                    <mainClass>org.shark.melian.MelianApplication</mainClass>
                 </configuration>
             </plugin>
             <plugin>
@@ -246,7 +249,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>org.shark.melian.mcp.MelianMcpServer</mainClass>
+                            <mainClass>org.shark.melian.MelianApplication</mainClass>
                         </manifest>
                     </archive>
                 </configuration>
@@ -264,7 +267,7 @@
                         <configuration>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.shark.melian.mcp.MelianMcpServer</mainClass>
+                                    <mainClass>org.shark.melian.MelianApplication</mainClass>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/src/main/java/org/shark/melian/MelianApplication.java
+++ b/src/main/java/org/shark/melian/MelianApplication.java
@@ -1,0 +1,69 @@
+package org.shark.melian;
+
+import org.shark.melian.client.TMDBApiClientPure;
+import org.shark.melian.config.DatabaseConfig;
+import org.shark.melian.config.MelianConfig;
+import org.shark.melian.config.MongoConfig;
+import org.shark.melian.mcp.PureMcpServer;
+import org.shark.melian.service.MongoMovieChunkServicePure;
+import org.shark.melian.service.SqlMovieChunkServicePure;
+import org.shark.melian.service.TMDBServicePure;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Spring Boot application that exposes MCP endpoints with Swagger documentation.
+ */
+@SpringBootApplication
+public class MelianApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MelianApplication.class, args);
+    }
+
+    @Bean
+    public MelianConfig melianConfig() {
+        return new MelianConfig();
+    }
+
+    @Bean
+    public DatabaseConfig databaseConfig(MelianConfig config) {
+        return new DatabaseConfig(config);
+    }
+
+    @Bean
+    public MongoConfig mongoConfig(MelianConfig config) {
+        return new MongoConfig(config);
+    }
+
+    @Bean
+    public TMDBApiClientPure tmdbApiClientPure(MelianConfig config) {
+        return new TMDBApiClientPure(config);
+    }
+
+    @Bean
+    public TMDBServicePure tmdbServicePure(TMDBApiClientPure client) {
+        return new TMDBServicePure(client);
+    }
+
+    @Bean
+    public SqlMovieChunkServicePure sqlMovieChunkServicePure(DatabaseConfig databaseConfig,
+                                                             TMDBServicePure tmdbService) {
+        return new SqlMovieChunkServicePure(databaseConfig, tmdbService);
+    }
+
+    @Bean
+    public MongoMovieChunkServicePure mongoMovieChunkServicePure(MongoConfig mongoConfig,
+                                                                 TMDBServicePure tmdbService) {
+        return new MongoMovieChunkServicePure(mongoConfig, tmdbService);
+    }
+
+    @Bean
+    public PureMcpServer pureMcpServer(TMDBServicePure tmdbService,
+                                       SqlMovieChunkServicePure sqlService,
+                                       MongoMovieChunkServicePure mongoService) {
+        return new PureMcpServer(tmdbService, sqlService, mongoService);
+    }
+}
+

--- a/src/main/java/org/shark/melian/config/SwaggerConfig.java
+++ b/src/main/java/org/shark/melian/config/SwaggerConfig.java
@@ -1,0 +1,12 @@
+package org.shark.melian.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+
+/**
+ * Basic OpenAPI configuration for Swagger UI.
+ */
+@OpenAPIDefinition(info = @Info(title = "Melian API", version = "1.0", description = "MCP server endpoints"))
+public class SwaggerConfig {
+}
+

--- a/src/main/java/org/shark/melian/rest/McpController.java
+++ b/src/main/java/org/shark/melian/rest/McpController.java
@@ -1,0 +1,95 @@
+package org.shark.melian.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import org.shark.melian.mcp.McpDto;
+import org.shark.melian.mcp.PureMcpServer;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Spring MVC controller exposing MCP endpoints.
+ */
+@RestController
+@RequestMapping("/mcp")
+public class McpController {
+
+    private final PureMcpServer mcpServer;
+    private final ObjectMapper objectMapper;
+
+    public McpController(PureMcpServer mcpServer, ObjectMapper objectMapper) {
+        this.mcpServer = mcpServer;
+        this.objectMapper = objectMapper;
+    }
+
+    @Operation(summary = "Handle MCP JSON-RPC requests")
+    @PostMapping
+    public McpDto.JsonRpcResponse handle(@RequestBody McpDto.JsonRpcRequest request) throws Exception {
+        Object result = handleMcpRequest(request);
+        return McpDto.JsonRpcResponse.builder()
+                .jsonrpc("2.0")
+                .result(result)
+                .id(request.getId())
+                .build();
+    }
+
+    private Object handleMcpRequest(McpDto.JsonRpcRequest request) throws Exception {
+        String method = request.getMethod();
+        Object params = request.getParams();
+
+        switch (method) {
+            case "initialize": {
+                McpDto.InitializeRequest initReq = objectMapper.convertValue(params, McpDto.InitializeRequest.class);
+                McpDto.InitializeResult result = mcpServer.initialize(initReq);
+                Map<String, Object> response = new HashMap<>();
+                response.put("serverInfo", result.getServerInfo());
+                response.put("capabilities", result.getCapabilities());
+                response.put("protocolVersion", result.getProtocolVersion());
+                return response;
+            }
+            case "tools/list":
+                return mcpServer.listTools();
+            case "tools/call": {
+                McpDto.CallToolRequest callReq = objectMapper.convertValue(params, McpDto.CallToolRequest.class);
+                return mcpServer.callTool(callReq);
+            }
+            case "resources/list":
+                return mcpServer.listResources();
+            case "resources/read": {
+                McpDto.ReadResourceRequest readReq = objectMapper.convertValue(params, McpDto.ReadResourceRequest.class);
+                return mcpServer.readResource(readReq);
+            }
+            default:
+                throw new IllegalArgumentException("Unknown method: " + method);
+        }
+    }
+
+    @Operation(summary = "Health check")
+    @GetMapping("/health")
+    public McpDto.HealthStatus health() {
+        return mcpServer.getHealth();
+    }
+
+    @Operation(summary = "List available tools")
+    @GetMapping("/tools")
+    public McpDto.ToolsListResult tools() {
+        return mcpServer.listTools();
+    }
+
+    @Operation(summary = "List or read resources")
+    @GetMapping("/resources")
+    public Object resources(@RequestParam(value = "uri", required = false) String uri) {
+        if (uri != null) {
+            return mcpServer.readResource(McpDto.ReadResourceRequest.builder().uri(uri).build());
+        }
+        return mcpServer.listResources();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Spring Boot web and Swagger dependencies
- expose MCP endpoints via new Spring controllers
- configure basic OpenAPI metadata

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.11: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d7452f0b8832eac70c76fb89081a7