### PR TITLE
Make movie search locale configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ export MCP_PURE_MODE=true
 export DISABLE_OPENAI=true
 ```
 
+#### Configuración del idioma de búsqueda
+
+El idioma utilizado para las búsquedas en MongoDB se controla mediante la propiedad `melian.search.locale` en `application.yml`.
+Por defecto se usa `en`, pero puede cambiarse, por ejemplo, a español:
+
+```yaml
+melian:
+  search:
+    locale: es
+```
+
 #### Endpoints MCP Estándar:
 
 - **JSON-RPC**: `POST /mcp` - Endpoint principal MCP con métodos estándar

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>5.4.0</version>

--- a/src/main/java/org/shark/melian/repository/MovieDocumentRepository.java
+++ b/src/main/java/org/shark/melian/repository/MovieDocumentRepository.java
@@ -34,9 +34,9 @@ public interface MovieDocumentRepository extends MongoRepository<MovieDocument, 
  * Interfaz para métodos personalizados
  */
 interface CustomMovieDocumentRepository {
-    List<MovieDocument> searchByTitle(String query, Pageable pageable);
-    List<MovieDocument> searchByTitleExact(String exactTitle);
-    List<MovieDocument> searchByTitleFuzzy(String query, Pageable pageable);
+    List<MovieDocument> searchByTitle(String query, Pageable pageable, String locale);
+    List<MovieDocument> searchByTitleExact(String exactTitle, String locale);
+    List<MovieDocument> searchByTitleFuzzy(String query, Pageable pageable, String locale);
 }
 
 /**
@@ -50,7 +50,7 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
     private MongoTemplate mongoTemplate;
 
     @Override
-    public List<MovieDocument> searchByTitle(String query, Pageable pageable) {
+    public List<MovieDocument> searchByTitle(String query, Pageable pageable, String locale) {
         query = query.trim().replaceAll("\\s+", " ");
         log.info("Buscando películas con título que contenga: '{}'", query);
 
@@ -67,7 +67,7 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
             mongoQuery.addCriteria(Criteria.where("title").regex(".*" + query + ".*", "i"));
         }
 
-        mongoQuery.with(pageable).collation(Collation.of("en").strength(1));
+        mongoQuery.with(pageable).collation(Collation.of(locale).strength(1));
         List<MovieDocument> results = mongoTemplate.find(mongoQuery, MovieDocument.class);
         log.info("Encontradas {} películas para consulta: '{}'", results.size(), query);
 
@@ -75,7 +75,7 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
     }
 
     @Override
-    public List<MovieDocument> searchByTitleExact(String exactTitle) {
+    public List<MovieDocument> searchByTitleExact(String exactTitle, String locale) {
         exactTitle = exactTitle.trim();
         log.info("Buscando películas con título exacto: '{}'", exactTitle);
 
@@ -84,7 +84,7 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
                 Criteria.where("title").is(exactTitle),
                 Criteria.where("orig_title").is(exactTitle)
         ));
-        mongoQuery.collation(Collation.of("en").strength(1));
+        mongoQuery.collation(Collation.of(locale).strength(1));
 
         List<MovieDocument> results = mongoTemplate.find(mongoQuery, MovieDocument.class);
         log.info("Encontradas {} películas con título exacto: '{}'", results.size(), exactTitle);
@@ -93,7 +93,7 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
     }
 
     @Override
-    public List<MovieDocument> searchByTitleFuzzy(String query, Pageable pageable) {
+    public List<MovieDocument> searchByTitleFuzzy(String query, Pageable pageable, String locale) {
         query = query.trim().replaceAll("\\s+", " ");
         log.info("Realizando búsqueda fuzzy para: '{}'", query);
 
@@ -104,7 +104,7 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
         );
 
         Query mongoQuery = new Query(criteria);
-        mongoQuery.with(pageable).collation(Collation.of("en").strength(1));
+        mongoQuery.with(pageable).collation(Collation.of(locale).strength(1));
 
         List<MovieDocument> results = mongoTemplate.find(mongoQuery, MovieDocument.class);
         log.info("Encontradas {} películas en búsqueda fuzzy para: '{}'", results.size(), query);

--- a/src/main/java/org/shark/melian/service/MongoMovieChunkService.java
+++ b/src/main/java/org/shark/melian/service/MongoMovieChunkService.java
@@ -6,6 +6,7 @@ import org.shark.melian.document.MovieDocument;
 import org.shark.melian.model.ChunkDto;
 import org.shark.melian.model.MovieResult;
 import org.shark.melian.repository.MovieDocumentRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +28,9 @@ public class MongoMovieChunkService implements MovieChunkService {
 
     private final MovieDocumentRepository movieDocumentRepository;
     private final TMDBService tmdbService;
+
+    @Value("${melian.search.locale:en}")
+    private String searchLocale;
 
     @Override
     public void storeMovies(List<MovieResult> movies) {
@@ -94,14 +98,14 @@ public class MongoMovieChunkService implements MovieChunkService {
         Pageable pageable = PageRequest.of(0, limit);
         String cleanedQuery = query.trim().replaceAll("\\s+", " ");
 
-        List<MovieDocument> movies = movieDocumentRepository.searchByTitle(cleanedQuery, pageable);
+        List<MovieDocument> movies = movieDocumentRepository.searchByTitle(cleanedQuery, pageable, searchLocale);
 
         if (movies.isEmpty()) {
-            movies = movieDocumentRepository.searchByTitleFuzzy(cleanedQuery, pageable);
+            movies = movieDocumentRepository.searchByTitleFuzzy(cleanedQuery, pageable, searchLocale);
         }
 
         if (movies.isEmpty()) {
-            movies = movieDocumentRepository.searchByTitleExact(cleanedQuery);
+            movies = movieDocumentRepository.searchByTitleExact(cleanedQuery, searchLocale);
         }
 
         return movies.stream()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,10 @@ tmdb:
   api-url: https://api.themoviedb.org/3
   access-token: eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJkYzEzOThhZDciMTY4ZjM2ZGJkMGIzYTZmYTYzOThhYSIsIm5iZiI6MTc0OTkzNDEyNi4xNDgsInN1YiI6IjY4NGRlMDJlYzgzZWJlNzgxOWJiNGU1YyIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.oI0cWBV3BQmfGNqjh27YLAqNuZK2gIQW-wkYeamNv5Y
 
+melian:
+  search:
+    locale: en
+
 
 logging:
   level:

--- a/src/test/java/org/shark/melian/repository/MovieDocumentRepositoryLocaleTest.java
+++ b/src/test/java/org/shark/melian/repository/MovieDocumentRepositoryLocaleTest.java
@@ -1,0 +1,77 @@
+package org.shark.melian.repository;
+
+import com.mongodb.client.MongoClients;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.runtime.Network;
+import org.junit.jupiter.api.*;
+import org.shark.melian.document.MovieDocument;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Tests for locale-aware search in MovieDocumentRepository.
+ */
+public class MovieDocumentRepositoryLocaleTest {
+
+    private static MongodExecutable mongodExecutable;
+    private static int port;
+
+    private MongoTemplate mongoTemplate;
+    private CustomMovieDocumentRepositoryImpl repository;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        port = Network.getFreeServerPort();
+        MongodConfig config = MongodConfig.builder()
+                .version(Version.Main.V6_0)
+                .net(new Net(port, Network.localhostIsIPv6()))
+                .build();
+        mongodExecutable = MongodStarter.getDefaultInstance().prepare(config);
+        mongodExecutable.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (mongodExecutable != null) {
+            mongodExecutable.stop();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        mongoTemplate = new MongoTemplate(MongoClients.create("mongodb://localhost:" + port), "test");
+        repository = new CustomMovieDocumentRepositoryImpl();
+        try {
+            var field = CustomMovieDocumentRepositoryImpl.class.getDeclaredField("mongoTemplate");
+            field.setAccessible(true);
+            field.set(repository, mongoTemplate);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        mongoTemplate.dropCollection(MovieDocument.class);
+        MovieDocument movie = new MovieDocument("El niño", "desc", "2024", 8.5);
+        mongoTemplate.save(movie);
+    }
+
+    @Test
+    void searchSpanishLocale() {
+        List<MovieDocument> results = repository.searchByTitle("nino", PageRequest.of(0, 10), "es");
+        Assertions.assertEquals(1, results.size());
+        Assertions.assertEquals("El niño", results.get(0).getTitle());
+    }
+
+    @Test
+    void searchEnglishLocale() {
+        List<MovieDocument> results = repository.searchByTitle("nino", PageRequest.of(0, 10), "en");
+        Assertions.assertEquals(1, results.size());
+        Assertions.assertEquals("El niño", results.get(0).getTitle());
+    }
+}


### PR DESCRIPTION
## Summary
- allow specifying collation locale for Mongo movie searches
- expose `melian.search.locale` property and document usage
- add tests covering searches in English and Spanish

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 or one of its dependencies could not be resolved: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.11 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68933decbd68832e975643be56d6b6cc