### PR TITLE
Use numeric rating in movie documents

### DIFF
--- a/src/main/java/org/shark/melian/document/MovieDocument.java
+++ b/src/main/java/org/shark/melian/document/MovieDocument.java
@@ -20,7 +20,7 @@ public class MovieDocument {
 
     private String title;
     private String releaseDate;
-    private Object rating;
+    private Double rating;
     private String genre;
     private String overview;
     private String crew;

--- a/src/main/java/org/shark/melian/service/MongoMovieChunkService.java
+++ b/src/main/java/org/shark/melian/service/MongoMovieChunkService.java
@@ -114,26 +114,20 @@ public class MongoMovieChunkService implements MovieChunkService {
                 .toList();
     }
 
-    private double convertRating(Object rating) {
-        if (rating == null) return 0.0;
-        if (rating instanceof Number) return ((Number) rating).doubleValue();
-        try {
-            return Double.parseDouble(rating.toString());
-        } catch (Exception e) {
-            log.warn("No se pudo convertir el rating '{}' a double: {}", rating, e.getMessage());
-            return 0.0;
-        }
+    private double convertRating(Double rating) {
+        return java.util.Optional.ofNullable(rating).orElse(0.0);
     }
 
     private ChunkDto mapMovieToChunk(MovieDocument movie) {
         ChunkDto chunk = new ChunkDto();
         chunk.setId(movie.getId());
 
+        double rating = convertRating(movie.getRating());
         String text = String.format("Movie: %s (%s)\nOverview: %s\nRating: %.1f",
                 movie.getTitle(),
                 movie.getReleaseDate() != null ? movie.getReleaseDate() : "Unknown",
                 movie.getOverview() != null ? movie.getOverview() : "No overview available",
-                convertRating(movie.getRating()));
+                rating);
         chunk.setText(text);
 
         Map<String, Object> metadata = new HashMap<>();
@@ -141,7 +135,7 @@ public class MongoMovieChunkService implements MovieChunkService {
         metadata.put("title", movie.getTitle());
         metadata.put("overview", movie.getOverview());
         metadata.put("release_date", movie.getReleaseDate());
-        metadata.put("rating", convertRating(movie.getRating()));
+        metadata.put("rating", rating);
 
         if (movie.getGenre() != null) metadata.put("genre", movie.getGenre());
         if (movie.getOrig_title() != null) metadata.put("orig_title", movie.getOrig_title());

--- a/src/main/mongo/init-movies.js
+++ b/src/main/mongo/init-movies.js
@@ -12,7 +12,7 @@ db.movies.insertMany([
     _id: ObjectId(),
     title: "The Matrix",
     releaseDate: "1999-03-31",
-    rating: 8.7,
+    rating: 8.7, // stored as number
     genre: ["Action", "Sci-Fi"],
     description: "A computer programmer is led to fight an underground war against powerful computers who have constructed his entire reality with a system called the Matrix.",
     imdbId: "tt0133093",
@@ -37,7 +37,7 @@ db.movies.insertMany([
     _id: ObjectId(),
     title: "Inception",
     releaseDate: "2010-07-16",
-    rating: 8.8,
+    rating: 8.8, // stored as number
     genre: ["Action", "Drama", "Sci-Fi"],
     description: "A thief who steals corporate secrets through the use of dream-sharing technology is given the inverse task of planting an idea into the mind of a C.E.O.",
     imdbId: "tt1375666", 

--- a/src/test/java/org/shark/melian/document/MovieDocumentTest.java
+++ b/src/test/java/org/shark/melian/document/MovieDocumentTest.java
@@ -1,0 +1,37 @@
+package org.shark.melian.document;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MovieDocumentTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void shouldSerializeAndDeserializeRating() throws Exception {
+        MovieDocument movie = new MovieDocument("Test", "Overview", "2024", 8.5);
+
+        String json = mapper.writeValueAsString(movie);
+        JsonNode node = mapper.readTree(json);
+        assertTrue(node.get("rating").isNumber());
+        assertEquals(8.5, node.get("rating").doubleValue());
+
+        MovieDocument result = mapper.readValue(json, MovieDocument.class);
+        assertEquals(8.5, result.getRating());
+    }
+
+    @Test
+    void shouldHandleNullRating() throws Exception {
+        MovieDocument movie = new MovieDocument("Test", "Overview", "2024", null);
+
+        String json = mapper.writeValueAsString(movie);
+        JsonNode node = mapper.readTree(json);
+        assertTrue(node.get("rating").isNull());
+
+        MovieDocument result = mapper.readValue(json, MovieDocument.class);
+        assertNull(result.getRating());
+    }
+}


### PR DESCRIPTION
## Summary
- treat rating as a `Double` instead of `Object` in `MovieDocument`
- simplify rating conversion in `MongoMovieChunkService` and default to 0 when missing
- document numeric ratings in init script and add serialization tests

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving Jacoco plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68933def3528832eba70dac667bfbd5e