### PR TITLE
feat: improve mongo title search

### DIFF
--- a/src/main/java/org/shark/melian/repository/MovieDocumentRepository.java
+++ b/src/main/java/org/shark/melian/repository/MovieDocumentRepository.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 import java.text.Normalizer;
+import java.util.Arrays;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -51,15 +53,29 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    private static final Set<String> STOP_WORDS = Set.of("the", "a", "an", "of", "and");
+
+    private String[] prepareWords(String query) {
+        String normalized = Normalizer.normalize(query, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .toLowerCase()
+                .trim()
+                .replaceAll("\\s+", " ");
+        return Arrays.stream(normalized.split(" "))
+                .filter(word -> !STOP_WORDS.contains(word))
+                .toArray(String[]::new);
+    }
+
     @Override
     public List<MovieDocument> searchByTitle(String query, Pageable pageable, String locale) {
-        query = query.trim().replaceAll("\\s+", " ");
-        String normalizedQuery = Normalizer.normalize(query, Normalizer.Form.NFD).replaceAll("\\p{M}", "");
-        log.info("Buscando películas con título que contenga: '{}'", normalizedQuery);
+        String[] words = prepareWords(query);
+        if (words.length == 0) {
+            return List.of();
+        }
+        log.info("Buscando películas con título que contenga: '{}'", String.join(" ", words));
 
         Query mongoQuery = new Query();
 
-        String[] words = normalizedQuery.split(" ");
         if (words.length > 1) {
             Criteria[] criterias = new Criteria[words.length];
             for (int i = 0; i < words.length; i++) {
@@ -69,11 +85,10 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
             }
             mongoQuery.addCriteria(new Criteria().andOperator(criterias));
         } else {
-            String quotedQuery = Pattern.quote(normalizedQuery);
+            String quotedQuery = Pattern.quote(words[0]);
             mongoQuery.addCriteria(Criteria.where("title")
                     .regex(Pattern.compile(".*" + quotedQuery + ".*", Pattern.CASE_INSENSITIVE)));
         }
-
 
         mongoQuery.limit(pageable.getPageSize()).skip(pageable.getOffset());
         mongoQuery.with(pageable.getSort());
@@ -81,7 +96,7 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
         log.info("Consulta generada: {}", mongoQuery);
 
         List<MovieDocument> results = mongoTemplate.find(mongoQuery, MovieDocument.class);
-        log.info("Encontradas {} películas para consulta: '{}'", results.size(), normalizedQuery);
+        log.info("Encontradas {} películas para consulta: '{}'", results.size(), String.join(" ", words));
 
         return results;
     }
@@ -106,8 +121,11 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
 
     @Override
     public List<MovieDocument> searchByTitleFuzzy(String query, Pageable pageable, String locale) {
-        query = query.trim().replaceAll("\\s+", " ");
-        String normalizedQuery = Normalizer.normalize(query, Normalizer.Form.NFD).replaceAll("\\p{M}", "");
+        String[] words = prepareWords(query);
+        if (words.length == 0) {
+            return List.of();
+        }
+        String normalizedQuery = String.join(" ", words);
         log.info("Realizando búsqueda fuzzy para: '{}'", normalizedQuery);
 
         String quotedQuery = Pattern.quote(normalizedQuery);


### PR DESCRIPTION
## Summary
- remove common stop words before building MongoDB regex search to match titles missing leading articles

## Testing
- `mvn -q test` *(fails: org.jacoco:jacoco-maven-plugin 0.8.11 network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689353443734832eb118f7abcc8d01bb