### PR TITLE
Preserve query phrase in Mongo movie search

### DIFF
--- a/src/main/java/org/shark/melian/repository/MovieDocumentRepository.java
+++ b/src/main/java/org/shark/melian/repository/MovieDocumentRepository.java
@@ -15,8 +15,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 import java.text.Normalizer;
-import java.util.Arrays;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -53,50 +51,36 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
     @Autowired
     private MongoTemplate mongoTemplate;
 
-    private static final Set<String> STOP_WORDS = Set.of("the", "a", "an", "of", "and");
-
-    private String[] prepareWords(String query) {
-        String normalized = Normalizer.normalize(query, Normalizer.Form.NFD)
+    private String normalizeQuery(String query) {
+        return Normalizer.normalize(query, Normalizer.Form.NFD)
                 .replaceAll("\\p{M}", "")
-                .toLowerCase()
                 .trim()
                 .replaceAll("\\s+", " ");
-        return Arrays.stream(normalized.split(" "))
-                .filter(word -> !STOP_WORDS.contains(word))
-                .toArray(String[]::new);
     }
 
     @Override
     public List<MovieDocument> searchByTitle(String query, Pageable pageable, String locale) {
-        String[] words = prepareWords(query);
-        if (words.length == 0) {
+        String normalizedQuery = normalizeQuery(query);
+        if (normalizedQuery.isEmpty()) {
             return List.of();
         }
-        log.info("Buscando películas con título que contenga: '{}'", String.join(" ", words));
+        log.info("Buscando películas con título que contenga: '{}'", normalizedQuery);
 
-        Query mongoQuery = new Query();
+        Pattern pattern = Pattern.compile(".*" + Pattern.quote(normalizedQuery) + ".*", Pattern.CASE_INSENSITIVE);
+        Criteria criteria = new Criteria().orOperator(
+                Criteria.where("title").regex(pattern),
+                Criteria.where("orig_title").regex(pattern)
+        );
 
-        if (words.length > 1) {
-            Criteria[] criterias = new Criteria[words.length];
-            for (int i = 0; i < words.length; i++) {
-                String quotedWord = Pattern.quote(words[i]);
-                criterias[i] = Criteria.where("title")
-                        .regex(Pattern.compile(".*" + quotedWord + ".*", Pattern.CASE_INSENSITIVE));
-            }
-            mongoQuery.addCriteria(new Criteria().andOperator(criterias));
-        } else {
-            String quotedQuery = Pattern.quote(words[0]);
-            mongoQuery.addCriteria(Criteria.where("title")
-                    .regex(Pattern.compile(".*" + quotedQuery + ".*", Pattern.CASE_INSENSITIVE)));
-        }
+        Query mongoQuery = new Query(criteria);
 
         mongoQuery.limit(pageable.getPageSize()).skip(pageable.getOffset());
         mongoQuery.with(pageable.getSort());
-        mongoQuery.collation(Collation.of("en").strength(1));
+        mongoQuery.collation(Collation.of(locale).strength(1));
         log.info("Consulta generada: {}", mongoQuery);
 
         List<MovieDocument> results = mongoTemplate.find(mongoQuery, MovieDocument.class);
-        log.info("Encontradas {} películas para consulta: '{}'", results.size(), String.join(" ", words));
+        log.info("Encontradas {} películas para consulta: '{}'", results.size(), normalizedQuery);
 
         return results;
     }
@@ -121,15 +105,13 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
 
     @Override
     public List<MovieDocument> searchByTitleFuzzy(String query, Pageable pageable, String locale) {
-        String[] words = prepareWords(query);
-        if (words.length == 0) {
+        String normalizedQuery = normalizeQuery(query);
+        if (normalizedQuery.isEmpty()) {
             return List.of();
         }
-        String normalizedQuery = String.join(" ", words);
         log.info("Realizando búsqueda fuzzy para: '{}'", normalizedQuery);
 
-        String quotedQuery = Pattern.quote(normalizedQuery);
-        Pattern pattern = Pattern.compile(".*" + quotedQuery + ".*", Pattern.CASE_INSENSITIVE);
+        Pattern pattern = Pattern.compile(".*" + Pattern.quote(normalizedQuery) + ".*", Pattern.CASE_INSENSITIVE);
         Criteria criteria = new Criteria().orOperator(
                 Criteria.where("title").regex(pattern),
                 Criteria.where("orig_title").regex(pattern),
@@ -140,7 +122,7 @@ class CustomMovieDocumentRepositoryImpl implements CustomMovieDocumentRepository
 
         mongoQuery.limit(pageable.getPageSize()).skip(pageable.getOffset());
         mongoQuery.with(pageable.getSort());
-        mongoQuery.collation(Collation.of("en").strength(1));
+        mongoQuery.collation(Collation.of(locale).strength(1));
         log.info("Consulta generada: {}", mongoQuery);
 
         List<MovieDocument> results = mongoTemplate.find(mongoQuery, MovieDocument.class);


### PR DESCRIPTION
## Summary
- Preserve original search phrase when querying MongoDB movies
- Search across `title` and `orig_title` without removing words

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 or one of its dependencies could not be resolved: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689356f76b7c832ea09f380c935c93d3