### PR TITLE
Trim movie search queries

### DIFF
--- a/src/main/java/org/shark/melian/mcp/PureMcpServer.java
+++ b/src/main/java/org/shark/melian/mcp/PureMcpServer.java
@@ -200,7 +200,8 @@ public class PureMcpServer {
 
         try {
             Map<String, Object> params = (Map<String, Object>) request.get("parameters");
-            String query = params.containsKey("query") ? params.get("query").toString() : "";
+            String rawQuery = params.containsKey("query") ? params.get("query").toString() : "";
+            String query = rawQuery.trim().replaceAll("\\s+", " ");
             int limit = params.containsKey("limit") ? Integer.parseInt(params.get("limit").toString()) : 10;
 
             log.info("[PureMcpServer] Buscando películas con query='{}', limit={}", query, limit);

--- a/src/main/java/org/shark/melian/service/AggregatedMovieService.java
+++ b/src/main/java/org/shark/melian/service/AggregatedMovieService.java
@@ -49,7 +49,8 @@ public class AggregatedMovieService {
      * Search movies from TMDB API and store in all available databases
      */
     public List<MovieResult> searchMovies(String query, int limit) {
-        log.info("Searching movies with query: '{}', limit: {}", query, limit);
+        String cleanedQuery = query != null ? query.trim().replaceAll("\\s+", " ") : "";
+        log.info("Searching movies with query: '{}', limit: {}", cleanedQuery, limit);
 
         List<CompletableFuture<List<MovieResult>>> futures = new ArrayList<>();
 
@@ -57,7 +58,7 @@ public class AggregatedMovieService {
         if (tmdbService != null) {
             futures.add(CompletableFuture.supplyAsync(() -> {
                 try {
-                    List<MovieResult> movies = tmdbService.search(query, limit);
+                    List<MovieResult> movies = tmdbService.search(cleanedQuery, limit);
                     log.info("Found {} movies from TMDB", movies.size());
                     return movies;
                 } catch (Exception e) {
@@ -71,7 +72,7 @@ public class AggregatedMovieService {
         if (sqlService != null) {
             futures.add(CompletableFuture.supplyAsync(() -> {
                 try {
-                    List<MovieResult> movies = sqlService.search(query, limit);
+                    List<MovieResult> movies = sqlService.search(cleanedQuery, limit);
                     log.info("Found {} movies from SQL", movies.size());
                     return movies;
                 } catch (Exception e) {
@@ -85,7 +86,7 @@ public class AggregatedMovieService {
         mongoService.ifPresent(service -> {
             futures.add(CompletableFuture.supplyAsync(() -> {
                 try {
-                    List<MovieResult> movies = service.search(query, limit);
+                    List<MovieResult> movies = service.search(cleanedQuery, limit);
                     log.info("Found {} movies from MongoDB", movies.size());
                     return movies;
                 } catch (Exception e) {

--- a/src/main/java/org/shark/melian/service/MongoMovieChunkService.java
+++ b/src/main/java/org/shark/melian/service/MongoMovieChunkService.java
@@ -93,10 +93,10 @@ public class MongoMovieChunkService implements MovieChunkService {
 
     @Override
     public List<MovieResult> search(String query, int limit) {
-        log.info("[MongoMovieChunkService] Searching local MongoDB for movies with title LIKE: {} (limit: {})", query, limit);
+        String cleanedQuery = query != null ? query.trim().replaceAll("\\s+", " ") : "";
+        log.info("[MongoMovieChunkService] Searching local MongoDB for movies with title LIKE: {} (limit: {})", cleanedQuery, limit);
 
         Pageable pageable = PageRequest.of(0, limit);
-        String cleanedQuery = query.trim().replaceAll("\\s+", " ");
 
         List<MovieDocument> movies = movieDocumentRepository.searchByTitle(cleanedQuery, pageable, searchLocale);
 

--- a/src/main/java/org/shark/melian/service/SqlMovieChunkService.java
+++ b/src/main/java/org/shark/melian/service/SqlMovieChunkService.java
@@ -88,10 +88,11 @@ public class SqlMovieChunkService implements MovieChunkService {
     @Override
     @Transactional(readOnly = true)
     public List<MovieResult> search(String query, int limit) {
-        log.info("[SqlMovieChunkService] Searching local DB for movies with title LIKE: {} (limit: {})", query, limit);
+        String cleanedQuery = query != null ? query.trim().replaceAll("\\s+", " ") : "";
+        log.info("[SqlMovieChunkService] Searching local DB for movies with title LIKE: {} (limit: {})", cleanedQuery, limit);
 
         Pageable pageable = PageRequest.of(0, limit);
-        List<Movie> movies = movieRepository.searchByTitle(query, pageable);
+        List<Movie> movies = movieRepository.searchByTitle(cleanedQuery, pageable);
 
         return movies.stream()
                 .map(movie -> new MovieResult(

--- a/src/main/java/org/shark/melian/service/TMDBService.java
+++ b/src/main/java/org/shark/melian/service/TMDBService.java
@@ -20,7 +20,8 @@ public class TMDBService {
     private final TMDBApiClientPure tmdbApiClient;
 
     public List<MovieResult> search(String title, int limit) {
-        log.info("[TMDBService] Searching for movies with title: {} (limit: {})", title, limit);
-        return tmdbApiClient.searchMovies(title, limit);
+        String cleanedTitle = title != null ? title.trim().replaceAll("\\s+", " ") : "";
+        log.info("[TMDBService] Searching for movies with title: {} (limit: {})", cleanedTitle, limit);
+        return tmdbApiClient.searchMovies(cleanedTitle, limit);
     }
 }


### PR DESCRIPTION
## Summary
- sanitize search queries in MCP, aggregation, TMDB, SQL, and Mongo services to remove trailing whitespace

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68935da81608832e9158aa952d547aac